### PR TITLE
Thym sur une page à part

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,7 +19,8 @@
           <ul>
             <li><a href="https://sudweb.fr/blog/">Blog</a></li>
             <li><a href="{{ "/contact/" | relative_url }}">Contact</a></li>
-            <li><a href="{{ "/manifeste" | relative_url }}">Manifeste</a></li>
+            <li><a href="{{ "/manifeste/" | relative_url }}">Manifeste</a></li>
+            <li><a href="{{ "/thym/" | relative_url }}">La Thym</a></li>
             <li><a href="{{ "/mentions-legales/" | relative_url }}">Mentions légales</a></li>
 
           </ul>

--- a/index.html
+++ b/index.html
@@ -201,23 +201,3 @@ description: Deux journées pour faire le plein d’inspiration.
   
   <!-- nothing here! -->
 </div>
-
-<div class="cta-zone-1 section-margin">
-  <div class="wrapper">
-    <div class="text-center">
-      <section>
-        <h3 class="small-title-size">La Thym</h3>
-        <div class="grid-4 text-center">
-          {% assign members = site.data.thym_members | sort: "name" %}
-          {% for member in members %}
-          <section class="attendee">
-            <figure class="attendee-avatar"><img src="https://twitter.com/{{ member.twitter }}/profile_image?size=bigger" alt="">
-            </figure>
-            <h3 class="attendee-name"><a href="https://twitter.com/{{ member.twitter }}">{{ member.name }}</a></h3>
-          </section>
-          {% endfor %}
-        </div>
-      </section>
-    </div>
-  </div>
-</div>

--- a/manifeste.md
+++ b/manifeste.md
@@ -29,24 +29,4 @@ Voici les valeurs que nous partageons et véhiculons :
 15. **Confier** nos peurs, nos craintes et nos joies en toute humilité et sincérité.
 16. **Offrir** une nourriture saine et locale.
 
-<div class="cta-zone-1 section-margin">
-  <div class="wrapper">
-    <div class="text-center">
-      <section>
-        <h3 class="small-title-size">La Thym</h3>
-        <div class="grid-4 text-center">
-          {% assign members = site.data.thym_members | sort: "name" %}
-          {% for member in members %}
-          <section class="attendee">
-            <figure class="attendee-avatar"><img src="https://twitter.com/{{ member.twitter }}/profile_image?size=bigger" alt="">
-            </figure>
-            <h3 class="attendee-name"><a href="https://twitter.com/{{ member.twitter }}">{{ member.name }}</a></h3>
-          </section>
-          {% endfor %}
-        </div>
-      </section>
-    </div>
-  </div>
-</div>
-
 </div>

--- a/thym.md
+++ b/thym.md
@@ -1,0 +1,29 @@
+---
+title: La Thym
+description: "Une bienveillante bande de tisseurs de liens"
+permalink: /thym/
+---
+
+<div class="wrapper" markdown="1">
+
+<div class="cta-zone-1 section-margin">
+  <div class="wrapper">
+    <div class="text-center">
+      <section>
+        <h3 class="small-title-size">La Thym</h3>
+        <div class="grid-4 text-center">
+          {% assign members = site.data.thym_members | sort: "name" %}
+          {% for member in members %}
+          <section class="attendee">
+            <figure class="attendee-avatar"><img src="https://twitter.com/{{ member.twitter }}/profile_image?size=bigger" alt="">
+            </figure>
+            <h3 class="attendee-name"><a href="https://twitter.com/{{ member.twitter }}">{{ member.name }}</a></h3>
+          </section>
+          {% endfor %}
+        </div>
+      </section>
+    </div>
+  </div>
+</div>
+
+</div>


### PR DESCRIPTION
### Quel problème cette PR corrige-t-elle ?

- À force d'aller sur l'accueil, je ne voyais pas ce que la Thym faisait là, en plus elle était déjà présente dans "Le Manifeste", qui sera à terme notre CoC

### Quels sont les changement(s) apporté(s) ?

- Création d'une page dédiée Thym avec lien dans le footer.
- Retrait de l'accueil, retrait du manifeste.

Opportunité : comme l'avait proposé @Julia-barbelane, qu'à terme on témoigne tou·te·s de quelques mots sur cette page.

### Qui devrait être prévenu de cette demande ?

@sudweb/thym
