### PR TITLE
Style pour voir tout le texte d'intro sur la home

### DIFF
--- a/_sass/_team.scss
+++ b/_sass/_team.scss
@@ -33,6 +33,15 @@
   line-height: 1;
 }
 
+.journees {
+  margin: 0;
+}
+
+.journees a {
+  text-decoration: none;
+  color: inherit;
+}
+
 /* Image background */
 
 .lozad .credits {

--- a/index.html
+++ b/index.html
@@ -10,11 +10,11 @@ is_home: true
       <section>
         <h2 class="small-title-size">Vendredi 25 et samedi 26 mai 2018 à
           <a href="https://www.google.fr/maps/place/Val+de+l'Hort/@44.0404289,3.988418,15z/data=!4m2!3m1!1s0x0:0xb1be8c54dae86e11?sa=X&ved=0ahUKEwiE3fSmhr7YAhUDOxQKHT5gD64Q_BIIfjAK"
-            target="_blank" rel="noopener noreferrer">Anduze, Gard (30)
+            target="_blank" rel="noopener noreferrer">Anduze, Gard&nbsp;(30)
             <span class="sr-only">(ouvrir dans une nouvelle fenêtre)</span>
           </a>
         </h2>
-        <h3 class="tiny-title-size uppercase">
+        <h3 class="tiny-title-size uppercase journees">
           <a href="#conferences">Une journée de conférences</a>
           <span class="title-plus">+</span>
           <a href="#forum-ouvert">Une journée de Forum Ouvert</a>


### PR DESCRIPTION
### Quel problème cette PR corrige-t-elle ?

Sur desktop par défaut le cta en bas de page était coupé (pas très beau). Les liens avec "journée de conférences", "journée de forum ouvert" => pas terrible non plus

### Quels sont les changement(s) apporté(s) ?

- Style des liens comme du texte
- Suppressions des marges pour faire remonter le cta
-

### Qui devrait être prévenu de cette demande ?

@sudweb/thym
