### PR TITLE
Correction d'une coquille dans 'lightning-talk' (page appel à sujets)

### DIFF
--- a/appel-a-sujets.html
+++ b/appel-a-sujets.html
@@ -16,7 +16,7 @@ image:
         <p>Toutes les formes de conférences sont possibles :</p>
         <ul>
           <li>présentation avec support(s) visuel(s) ;</li>
-          <li><abbr lang="en">lighting talk</abbr> ;</li>
+          <li><span lang="en">lightning talk</span> ;</li>
           <li>conférence gesticulée ;</li>
           <li>activité de groupe…</li>
         </ul>


### PR DESCRIPTION
### Quel problème cette PR corrige-t-elle ?

- `lighting-talk` se traduit par `conférence éclair`
- `lightNing-talk` se traduit par `conférence-éclair`
La différence est subtile, mais ça vaut le coup de corriger :-)

### Quels sont les changement(s) apporté(s) ?

- Ajout d'un `n` dans `lightning talk`
- Remplacement de la balise `abbr` par un `span` (parce que ce n'est pas une abréviation)

### Qui devrait être prévenu de cette demande ?

@sudweb/thym
