### PR TITLE
Styles : Interligne des titres de niveaux 1 et 2

### DIFF
--- a/_sass/base/_typo.scss
+++ b/_sass/base/_typo.scss
@@ -22,7 +22,7 @@ body {
 }
 
 h1, h2, .h-like {
-	font-family: $title-font-family; font-style: $title-font-style; font-weight: $title-font-weight;
+	font-family: $title-font-family; font-style: $title-font-style; font-weight: $title-font-weight; line-height: $title-line-height;
 }
 
 h3, h4, h5, h6 {

--- a/_sass/scss/_config.scss
+++ b/_sass/scss/_config.scss
@@ -64,6 +64,7 @@ $main-title-font-style      : normal;
 $title-font-family          : "Roboto", arial, sans-serif;
 $title-font-weight          : $font-weight-light;
 $title-font-style           : normal;
+$title-line-height          : 1.2;
 
 $nav-font-family            : "Roboto", arial, sans-serif;
 $nav-font-weight            : $font-weight-light;


### PR DESCRIPTION
### Quel problème cette PR corrige-t-elle ?

L'interligne par défaut est un peu trop important pour les niveaux de titres supérieurs

### Quels sont les changement(s) apporté(s) ?

- Définition d'un interlignage par défaut pour les gros titres
- Proposition de passer l'interligne à 1.2 au lieu de 1.6

Aperçu avant/après:

![title-line-height](https://user-images.githubusercontent.com/103008/36673970-e3726482-1b04-11e8-848d-473d93b6b56b.png)




### Qui devrait être prévenu de cette demande ?

@sudweb/thym
