### PR TITLE
Quick nav

### DIFF
--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -12,6 +12,8 @@ en_US:
   "code-de-conduite": "code-of-conduct"
   "proposer un sujet": "call for proposals"
   "réserver votre place": "register now!"
+  "Aller directement à l'intervention de %s": "Go directly to %s talk"
+  "Aller directement au programme détaillé": "Go directly to the detailed line-up"
   "Venir à Sud Web 2018": "Come to Sud Web 2018"
   "Programme": "Line-up"
   "programme": "line-up"

--- a/_includes/conferences.html
+++ b/_includes/conferences.html
@@ -5,7 +5,6 @@
   {% assign verbatim = conference.fr_FR %}
 {% endif %}
 
-<hr>
 <article class="conference" id="{{ conference.slug }}">
   <h2>
     {{ verbatim.title }}&nbsp;<a href="#{{ conference.slug }}" class="text-xs">#</a>

--- a/_includes/conferences.html
+++ b/_includes/conferences.html
@@ -1,39 +1,43 @@
-{% for conference in include.conferences %}
-{% if include.locale == "en_US" and conference.en_US %}
-  {% assign verbatim = conference.en_US %}
-{% else %}
-  {% assign verbatim = conference.fr_FR %}
-{% endif %}
-
-<article class="conference" id="{{ conference.slug }}">
-  <h2>
-    {{ verbatim.title }}&nbsp;<a href="#{{ conference.slug }}" class="text-xs">#</a>
-  </h2>
-  {{ verbatim.description | markdownify }}
-    {% for names in conference.speaker %}
-    {% assign speaker = site.data.speakers[names] %}
-    {% if include.locale == "en_US" and speaker.en_US %}
-      {% assign speakatim = speaker.en_US %}
+<section class="section">
+  <div class="wrapper">
+    {% for conference in include.conferences %}
+    {% if include.locale == "en_US" and conference.en_US %}
+      {% assign verbatim = conference.en_US %}
     {% else %}
-      {% assign speakatim = speaker.fr_FR %}
+      {% assign verbatim = conference.fr_FR %}
     {% endif %}
-    <section class="conference-speaker text-sm">
-      <figure class="conference-speaker-pic" role="group">
-        <img src="{{ speaker.image | relative_url }}" alt="">
-        <figcaption class="sr-only">{{ speaker.name }}</figcaption>
-      </figure>
-      <h3 class="conference-speaker-name">
-        <span class="text-xs">{% t Présenté par %}</span><br>
-        {% capture person %}<em>{{ speaker.name }}</em>{% endcapture %}
-        {% if speaker.url %}
-          {% capture person %}<a href="{{ speaker.url }}">{{ person }}</a>{% endcapture %}
+    <article class="conference" id="{{ conference.slug }}">
+      <h2>
+        {{ verbatim.title }}&nbsp;<a href="#{{ conference.slug }}" class="text-xs">#</a>
+      </h2>
+      {{ verbatim.description | markdownify }}
+        {% for names in conference.speaker %}
+        {% assign speaker = site.data.speakers[names] %}
+        {% if include.locale == "en_US" and speaker.en_US %}
+          {% assign speakatim = speaker.en_US %}
+        {% else %}
+          {% assign speakatim = speaker.fr_FR %}
         {% endif %}
-        {{ person }}
-      </h3>
-      <p class="conference-speaker-description">
-        {{ speakatim.bio }}
-      </p>
-    </section>
+        <section class="conference-speaker text-sm">
+          <figure class="conference-speaker-pic" role="group">
+            <img src="{{ speaker.image | relative_url }}" alt="">
+            <figcaption class="sr-only">{{ speaker.name }}</figcaption>
+          </figure>
+          <h3 class="conference-speaker-name">
+            <span class="text-xs">{% t Présenté par %}</span><br>
+            {% capture person %}<em>{{ speaker.name }}</em>{% endcapture %}
+            {% if speaker.url %}
+              {% capture person %}<a href="{{ speaker.url }}">{{ person }}</a>{% endcapture %}
+            {% endif %}
+            {{ person }}
+          </h3>
+          <p class="conference-speaker-description">
+            {{ speakatim.bio }}
+          </p>
+        </section>
+        {%- endfor -%}
+    </article>
     {%- endfor -%}
-</article>
-{%- endfor -%}
+  </div>
+</section>
+

--- a/_includes/header-home.html
+++ b/_includes/header-home.html
@@ -30,3 +30,12 @@
     </p>
   </div>
 </header>
+
+<section class="section">
+  <div class="wrapper">
+    <hr>
+  </div>
+</section>
+
+{%- assign conferences = site.talks | sort: "display-order" -%}
+{% include speakers.html conferences=conferences locale=page.locale %}

--- a/_includes/speakers.html
+++ b/_includes/speakers.html
@@ -8,11 +8,11 @@
 {%- endfor -%}
 <section id="speakers" class="section">
   <div class="wrapper">
-    <a class="sr-only" src="{% unless include.shorturl %}{{ "programme" | t: include.locale | relative_url }}{% endunless %}#conferences" >{% t Aller directement au programme détaillé %}</a>
+    <a class="sr-only" src="{% unless include.shorturl %}{{ page.baseurl | default:site.baseurl }}/{{ "programme" | t: include.locale }}{% endunless %}#conferences" >{% t Aller directement au programme détaillé %}</a>
     <div class="grid-{{ count | divided_by: 2 }} text-center">
       {% for conference in include.conferences %}
         {% for names in conference.speaker %}
-          {% capture conf-url %}{% unless include.shorturl %}{{ "programme" | t: include.locale | relative_url }}{% endunless %}#{{conference.slug}}{% endcapture %}
+          {% capture conf-url %}{% unless include.shorturl %}{{ page.baseurl | default:site.baseurl }}/{{ "programme" | t: include.locale }}{% endunless %}#{{conference.slug}}{% endcapture %}
           {% assign speaker = site.data.speakers[names] %}
           <figure class="person">
             <a title="{{ "Aller directement à l'intervention de %s" | t: include.locale | replace:"%s",speaker.name }}" href="{{ conf-url }}"><img src="{{ site.lazyload.placeholder }}" class="person-avatar lozad" data-src="{{ speaker.image | relative_url }}" alt="{{speaker.name}}" width="100" height="100"></a>

--- a/_includes/speakers.html
+++ b/_includes/speakers.html
@@ -1,60 +1,24 @@
-{% for conference in conferences %}
-<section class="pres-item">
-  {% if conference.type != 'pause' %}
-  <figure class="pres-type">
-    <svg width="1em" xmlns="http://www.w3.org/2000/svg" version="1.1">
-      <use id="sw-hands" xlink:href="{{ "/assets/images/symbol-defs.svg#link" | append: conference.symbol | relative_url }}" />
-    </svg>
-  </figure>
-  {% endif %}
-
-  <h4 class="pres-title tiny-title-size" id="{{ conference.title | slugify }}">{% comment %}{{ conference.date | date: "%Hh%M" }} : {% endcomment %}{{ conference.title }} <a class="orange link" href="#{{ conference.title | slugify }}"><svg width="1em" class="svg-size" viewBox="0 0 400 400"><use xlink:href="{{ "/assets/images/symbol-defs.svg#link" | relative_url }}" /></svg></a></h4>
-
-  <div class="pres-desc">
-    {{ conference.description | markdownify }}
-  </div>
-
-  <div class="pres-medias">
-    {% if conference.video %}
-    <div class="pres-medias-link">
-      <svg width="1em" xmlns="http://www.w3.org/2000/svg" version="1.1">
-        <use xlink:href="{{ "/assets/images/symbol-defs.svg#video" | relative_url }}" />
-      </svg>
-      <a href="{{ conference.video }}" title="Voir la vidéo '{{ conference.title }}'" data-event-category="cta" data-event-action="click" data-event-label="video-{{ conference.title | slugify }}">Vidéo</a>
+{% comment %} Collecting speakers count {% endcomment %}
+{% assign speakers = '' | split: '' %}
+{% assign count = 0 %}
+{% for conference in include.conferences %}
+  {% for names in conference.speaker %}
+    {% assign count = count | plus: 1 %}
+  {%- endfor -%}
+{%- endfor -%}
+<section id="speakers" class="section">
+  <div class="wrapper">
+    <a class="sr-only" src="{% unless include.shorturl %}{{ "programme" | t: include.locale | relative_url }}{% endunless %}#conferences" >{% t Aller directement au programme détaillé %}</a>
+    <div class="grid-{{ count | divided_by: 2 }} text-center">
+      {% for conference in include.conferences %}
+        {% for names in conference.speaker %}
+          {% capture conf-url %}{% unless include.shorturl %}{{ "programme" | t: include.locale | relative_url }}{% endunless %}#{{conference.slug}}{% endcapture %}
+          {% assign speaker = site.data.speakers[names] %}
+          <figure class="person">
+            <a title="{{ "Aller directement à l'intervention de %s" | t: include.locale | replace:"%s",speaker.name }}" href="{{ conf-url }}"><img src="{{ site.lazyload.placeholder }}" class="person-avatar lozad" data-src="{{ speaker.image | relative_url }}" alt="{{speaker.name}}" width="100" height="100"></a>
+          </figure>
+        {%- endfor -%}
+      {%- endfor -%}
     </div>
-    {% endif %}
-    {% if conference.slides %}
-    <div class="pres-medias-link">
-      <svg width="1em" xmlns="http://www.w3.org/2000/svg" version="1.1">
-        <use xlink:href="{{ "/assets/images/symbol-defs.svg#slides" | relative_url }}" />
-      </svg>
-      <a href="{{ conference.slides }}" title="Voir les slides '{{ conference.title }}'" data-event-category="cta" data-event-action="click" data-event-label="slides-{{ conference.title | slugify }}">Slides</a>
-    </div>
-    {% endif %}
   </div>
-
-  <footer>
-    {% for names in conference.speaker %}
-    {% assign speaker = site.data.speakers[names] %}
-    <section class="pres-author clearfix">
-      {% if speaker.name != 'sudweb' %}
-      <figure class="author-img">
-        {% capture spckimg %}/assets/images/orateurs/{% if speaker.slug %}{{ speaker.slug }}{% else %}{{ speaker.name | slugify }}{% endif %}.jpg{% endcapture %}
-        <img src="{{ spckimg | relative_url }}" alt="{{ speaker.name }}">
-      </figure>
-      {% endif %}
-      <h5 class="author-name default-size">
-        {% if speaker.website %}
-           <a href="{{speaker.website}}">{{ speaker.name }}</a>
-        {% elsif speaker.twitter %}
-            <a href="//twitter.com/{{speaker.twitter}}">{{ speaker.name }}</a>
-        {% else %}
-            {{ speaker.name }}
-        {% endif %}
-      </h5>
-      <div class="author-desc">{{ speaker.bio | markdownify }}</div>
-    </section>
-    {% endfor %}
-  </footer>
 </section>
-{% endfor %}

--- a/pages/en/programme.html
+++ b/pages/en/programme.html
@@ -16,9 +16,33 @@ permalink: /en/line-up/
     <p class="text-center"><a class="button" data-text="{% t réserver votre place %}" href="{{ page.baseurl | default:site.baseurl }}/{{ "billetterie" | t: page.locale }}/" title="{% t Venir à Sud Web 2018 %}">
       <span class="button-inner">{% t réserver votre place %}</span>
     </a></p>
+  </div>
+</section>
+
+<section class="section">
+  <div class="wrapper">
     <hr>
-    {% include conferences.html conferences=conferences locale=page.locale %}
+  </div>
+</section>
+
+{% include speakers.html conferences=conferences locale=page.locale shorturl=true %}
+
+<section class="section">
+  <div class="wrapper">
     <hr>
+  </div>
+</section>
+
+{% include conferences.html conferences=conferences locale=page.locale %}
+
+<section class="section">
+  <div class="wrapper">
+    <hr>
+  </div>
+</section>
+
+<section class="section">
+  <div class="wrapper">
     <p class="text-center"><a class="button" data-text="{% t réserver votre place %}" href="{{ page.baseurl | default:site.baseurl }}/{{ "billetterie" | t: page.locale }}/" title="{% t Venir à Sud Web 2018 %}">
       <span class="button-inner">{% t réserver votre place %}</span>
     </a></p>

--- a/pages/en/programme.html
+++ b/pages/en/programme.html
@@ -16,6 +16,7 @@ permalink: /en/line-up/
     <p class="text-center"><a class="button" data-text="{% t réserver votre place %}" href="{{ page.baseurl | default:site.baseurl }}/{{ "billetterie" | t: page.locale }}/" title="{% t Venir à Sud Web 2018 %}">
       <span class="button-inner">{% t réserver votre place %}</span>
     </a></p>
+    <hr>
     {% include conferences.html conferences=conferences locale=page.locale %}
     <hr>
     <p class="text-center"><a class="button" data-text="{% t réserver votre place %}" href="{{ page.baseurl | default:site.baseurl }}/{{ "billetterie" | t: page.locale }}/" title="{% t Venir à Sud Web 2018 %}">

--- a/pages/fr/programme.html
+++ b/pages/fr/programme.html
@@ -15,9 +15,33 @@ permalink: /programme/
     <p class="text-center"><a class="button" data-text="{% t réserver votre place %}" href="{{ page.baseurl | default:site.baseurl }}/{{ "billetterie" | t: page.locale }}/" title="{% t Venir à Sud Web 2018 %}">
       <span class="button-inner">{% t réserver votre place %}</span>
     </a></p>
+  </div>
+</section>
+
+<section class="section">
+  <div class="wrapper">
     <hr>
-    {% include conferences.html conferences=conferences locale=page.locale %}
+  </div>
+</section>
+
+{% include speakers.html conferences=conferences locale=page.locale shorturl=true %}
+
+<section class="section">
+  <div class="wrapper">
     <hr>
+  </div>
+</section>
+
+{% include conferences.html conferences=conferences locale=page.locale %}
+
+<section class="section">
+  <div class="wrapper">
+    <hr>
+  </div>
+</section>
+
+<section class="section">
+  <div class="wrapper">
     <p class="text-center"><a class="button" data-text="{% t réserver votre place %}" href="{{ page.baseurl | default:site.baseurl }}/{{ "billetterie" | t: page.locale }}/" title="{% t Venir à Sud Web 2018 %}">
       <span class="button-inner">{% t réserver votre place %}</span>
     </a></p>

--- a/pages/fr/programme.html
+++ b/pages/fr/programme.html
@@ -15,6 +15,7 @@ permalink: /programme/
     <p class="text-center"><a class="button" data-text="{% t réserver votre place %}" href="{{ page.baseurl | default:site.baseurl }}/{{ "billetterie" | t: page.locale }}/" title="{% t Venir à Sud Web 2018 %}">
       <span class="button-inner">{% t réserver votre place %}</span>
     </a></p>
+    <hr>
     {% include conferences.html conferences=conferences locale=page.locale %}
     <hr>
     <p class="text-center"><a class="button" data-text="{% t réserver votre place %}" href="{{ page.baseurl | default:site.baseurl }}/{{ "billetterie" | t: page.locale }}/" title="{% t Venir à Sud Web 2018 %}">


### PR DESCRIPTION
### Quel problème cette PR corrige-t-elle ?

On m'a fait remarqué qu'il était difficile d'avoir un aperçu rapide des intervenant·e·s sur la page du programme.

### Quels sont les changement(s) apporté(s) ?

Ajout d'une navigation rapide à base d'images + un lien en amont pour court-circuiter et appeler au programme détaillé.

Déployé ici : https://5a9ae645fd0efa73d04e7ccc--ranger-combat-60823.netlify.com/2018/

### Qui devrait être prévenu de cette demande ?

@sudweb/thym
