### PR TITLE
Add bike to travel.

### DIFF
--- a/pages/fr/venir-anduze.html
+++ b/pages/fr/venir-anduze.html
@@ -25,10 +25,13 @@ redirect_from:
 
     <ul>
       <li>
-        <a href="#car"> avec sa voiture ou en covoiturage</a>.
+        <a href="#car"> avec sa voiture ou en covoiturage</a> ;
       </li>
       <li>
         <a href="#public-transport"> en transports en commun</a> ;
+      </li>
+      <li>
+        <a href="#bike"> à vélo</a>.
       </li>
     </ul>
   </div>
@@ -170,6 +173,28 @@ redirect_from:
     </p>
   </div>
 </section>
+
+<section class="section">
+  <div class="wrapper">
+    <h2 id="bike">À vélo</h2>
+
+    <p>L'Hérault au mois de Mai, ça devrait être plutôt agréable.</p>
+
+    <ul>
+      <li>
+        <a href="http://cycle.travel/map?from=Al%C3%A8rs%2C%20place%20pierre%20semard&to=1050%20Chemin%20Bas%2030140%20Anduze&fromLL=&toLL=">Depuis la gare d'Alès</a>, c'est moins de 20km, et 140m de dénivelé positif. Donc une heure environ.<br>
+        Il y a la possibilité d'esquiver la D910a (si c'est trop passant) en visant Boisset.<br>
+        Les <a href="https://cdn.ter.sncf.com/medias/PDF/occitanie/FH25-NimesAles-V5_tcm76-172101_tcm76-172069.pdf">TER</a> permettent de transporter les vélos depuis Nîmes sans réservations.
+      </li>
+
+      <li>
+        <a href="http://cycle.travel/map?from=n%C3%AEmes%2C%20avenue%20feuch%C3%A8res&to=1050%20Chemin%20Bas%2C%20Anduze&fromLL=&toLL=">Depuis la gare de Nîmes</a>, c'est environ 45km, et 400m de dénivelé positif. <br>
+        C'est plus sportif.<br>
+      </li>
+    </ul>
+  </div>
+</section>
+
 
 {% include banners/hands.html locale=page.locale %}
 


### PR DESCRIPTION
### Quel problème cette PR corrige-t-elle ?

Fixes #84 

### Quels sont les changement(s) apporté(s) ?

J'ai rajouté les liens vers des intinéraires depuis la gare d'Alès et de Nîmes.
Les liens sont de cycle.travel et non OpenStreetMap, parce que ça optimise pour le vélo (et OSM rajoute 100m de dénivelé positif à un endroit, en contournant une colline).

Et le lien vers les horaires de TER Nîmes-Alès (pour éviter les cars qui ne prennent pas les vélos).
J'espère qu'il n'y a pas de fautes d'orthographes.


La version anglaise n'existant pas pour cette page, je ne l'ai pas rajoutée.

### Qui devrait être prévenu de cette demande ?

@sudweb/thym
